### PR TITLE
feat: implement serializable isolation level

### DIFF
--- a/db.go
+++ b/db.go
@@ -109,8 +109,6 @@ func (db *DB) Put(key, value []byte) error {
 }
 
 func (db *DB) Get(key []byte) ([]byte, error) {
-	db.mu.RLock()
-	defer db.mu.RUnlock()
 	if len(key) == 0 {
 		return nil, public.ErrKeyIsEmpty
 	}
@@ -279,8 +277,6 @@ func (db *DB) mergeWorker() {
 }
 
 func (db *DB) appendLogRecordWithLock(log *data.LogRecord) (*data.LogPos, error) {
-	db.mu.Lock()
-	defer db.mu.Unlock()
 	return db.appendLogRecord(log)
 }
 

--- a/public/errors.go
+++ b/public/errors.go
@@ -13,4 +13,5 @@ var (
 	ErrLuaInterpreterDisabled = errors.New("the lua Interpreter is not started, can not support execute lua script")
 	ErrTransactionConflict    = errors.New("transaction concurrency conflict, please try again")
 	ErrHeapEmpty              = errors.New("heap is empty")
+	ErrTxnFunctionEmpty       = errors.New("the txn function is empty")
 )

--- a/txn_test.go
+++ b/txn_test.go
@@ -1,0 +1,86 @@
+package CouloyDB
+
+import (
+	"log"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestSerializableTxn(t *testing.T) {
+	conf := DefaultOptions()
+	db, err := NewCouloyDB(conf)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	readLoop1 := func(txn *Txn) error {
+		for i := 1; i < 11; i++ {
+			v, _ := txn.Get([]byte(strconv.Itoa(i)))
+			log.Printf("Read key: %v, value: %v in read loop1", i, string(v))
+			time.Sleep(10 * time.Millisecond)
+		}
+		return nil
+	}
+
+	readLoop2 := func(txn *Txn) error {
+		for i := 1; i < 11; i++ {
+			v, _ := txn.Get([]byte(strconv.Itoa(i)))
+			log.Printf("Read key: %v, value: %v in read loop2", i, string(v))
+			time.Sleep(20 * time.Millisecond)
+		}
+		return nil
+	}
+
+	writeLoop1 := func(txn *Txn) error {
+		for i := 1; i <= 10; i++ {
+			err := txn.Put([]byte(strconv.Itoa(i)), []byte(strconv.Itoa(i)))
+			if err != nil {
+				return err
+			}
+			log.Printf("Write key: %v, value: %v in write loop1", i, i)
+		}
+		return nil
+	}
+
+	writeLoop2 := func(txn *Txn) error {
+		for i := 11; i <= 20; i++ {
+			err := txn.Put([]byte(strconv.Itoa(i)), []byte(strconv.Itoa(i)))
+			if err != nil {
+				return err
+			}
+			log.Printf("Write key: %v, value: %v in write loop2", i, i)
+		}
+		return nil
+	}
+
+	wg := sync.WaitGroup{}
+
+	wg.Add(1)
+	go func() {
+		_ = db.ReadOnlyTransaction(readLoop1)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		_ = db.ReadOnlyTransaction(readLoop2)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		_ = db.RWTransaction(true, writeLoop1)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		_ = db.RWTransaction(true, writeLoop2)
+		wg.Done()
+	}()
+
+	wg.Wait()
+	_ = db.Close()
+}


### PR DESCRIPTION
The serializable isolation level is achieved by acquiring a lock at the beginning of a transaction. Read-only transactions acquire the RLock of the database, allowing them to be executed concurrently. On the other hand, read-write transactions acquire the Lock of the database, allowing only one read-write transaction to be executed at a time. The lock is released when the transaction is committed or rolled back.