### PR TITLE
fix bugs of concurrency 

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -32,6 +32,7 @@ func TestNewCouloyDB(t *testing.T) {
 func TestDB_Put(t *testing.T) {
 	options := DefaultOptions()
 	options.DataFileSize = 8 * 1024 * 1024
+	options.SyncWrites = false
 	couloyDB, err := NewCouloyDB(options)
 	defer destroyCouloyDB(couloyDB)
 	assert.Nil(t, err)
@@ -66,6 +67,7 @@ func TestDB_Put(t *testing.T) {
 func TestDB_Get(t *testing.T) {
 	options := DefaultOptions()
 	options.DataFileSize = 8 * 1024 * 1024
+	options.SyncWrites = false
 	couloyDB, err := NewCouloyDB(options)
 	defer destroyCouloyDB(couloyDB)
 	assert.Nil(t, err)
@@ -104,9 +106,10 @@ func TestDB_Get(t *testing.T) {
 	assert.Equal(t, public.ErrKeyNotFound, err)
 }
 
-func TestDB_Put_Get_In_Parallel(t *testing.T) {
+func TestDB_Put_Get_Concurrency(t *testing.T) {
 	options := DefaultOptions()
 	options.DataFileSize = 8 * 1024 * 1024
+	options.SyncWrites = false
 	couloyDB, err := NewCouloyDB(options)
 	defer destroyCouloyDB(couloyDB)
 	assert.Nil(t, err)
@@ -180,6 +183,7 @@ func TestDB_Put_Get_In_Parallel(t *testing.T) {
 func TestDB_Del(t *testing.T) {
 	options := DefaultOptions()
 	options.DataFileSize = 8 * 1024 * 1024
+	options.SyncWrites = false
 	couloyDB, err := NewCouloyDB(options)
 	defer destroyCouloyDB(couloyDB)
 	assert.Nil(t, err)
@@ -209,6 +213,7 @@ func TestDB_Del(t *testing.T) {
 func TestDB_Reboot(t *testing.T) {
 	options := DefaultOptions()
 	options.DataFileSize = 8 * 1024 * 1024
+	options.SyncWrites = false
 	couloyDB, err := NewCouloyDB(options)
 	assert.Nil(t, err)
 	assert.NotNil(t, couloyDB)

--- a/meta/btree.go
+++ b/meta/btree.go
@@ -5,19 +5,16 @@ import (
 	"github.com/Kirov7/CouloyDB/data"
 	"github.com/google/btree"
 	"sort"
-	"sync"
 )
 
 type BTree struct {
 	tree *btree.BTree
-	lock *sync.RWMutex
 }
 
 // NewBTree Init BTree struct
 func NewBTree() *BTree {
 	return &BTree{
 		tree: btree.New(32),
-		lock: new(sync.RWMutex),
 	}
 }
 
@@ -26,8 +23,6 @@ func (bt *BTree) Put(key []byte, pos *data.LogPos) bool {
 		Key: key,
 		Pos: pos,
 	}
-	bt.lock.Lock()
-	defer bt.lock.Unlock()
 
 	bt.tree.ReplaceOrInsert(item)
 	return true
@@ -37,9 +32,6 @@ func (bt *BTree) Get(key []byte) *data.LogPos {
 	item := &Item{
 		Key: key,
 	}
-
-	bt.lock.RLock()
-	defer bt.lock.RUnlock()
 
 	value := bt.tree.Get(item)
 	if value == nil {
@@ -52,8 +44,6 @@ func (bt *BTree) Del(key []byte) bool {
 	item := &Item{
 		Key: key,
 	}
-	bt.lock.Lock()
-	defer bt.lock.Unlock()
 
 	value := bt.tree.Delete(item)
 	if value == nil {
@@ -79,8 +69,7 @@ func (bt *BTree) Iterator(reverse bool) Iterator {
 	if bt.tree == nil {
 		return nil
 	}
-	bt.lock.RLock()
-	defer bt.lock.RUnlock()
+
 	return newBtreeIterator(bt, reverse)
 }
 

--- a/ttl.go
+++ b/ttl.go
@@ -2,6 +2,7 @@ package CouloyDB
 
 import (
 	"github.com/Kirov7/CouloyDB/public/ds"
+	"log"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -90,7 +91,10 @@ func (ttl *ttl) exec() {
 		return
 	}
 
-	go ttl.deleter(job.Key)
+	go func() {
+		err := ttl.deleter(job.Key)
+		log.Printf("there is a error occured by deleter: %v", err.Error())
+	}()
 }
 
 func (ttl *ttl) notify() {

--- a/watch_test.go
+++ b/watch_test.go
@@ -3,7 +3,6 @@ package CouloyDB
 import (
 	"context"
 	"github.com/stretchr/testify/assert"
-	"log"
 	"testing"
 	"time"
 )
@@ -20,8 +19,6 @@ func TestDB_Watch(t *testing.T) {
 	defer cancel()
 
 	watchCh := db.Watch(ctx, key)
-
-	log.Printf("starting watch key")
 
 	go func() {
 		_ = db.Put([]byte(key), []byte("value1"))
@@ -41,11 +38,6 @@ func TestDB_Watch(t *testing.T) {
 			assert.Fail(t, "Context canceled before receiving all events")
 			return
 		case event, ok := <-watchCh:
-			if event.eventType == PutEvent {
-				log.Printf("The value of %v is changed to %v", event.key, string(event.value))
-			} else {
-				log.Printf("%v has been deleted", event.key)
-			}
 			assert.True(t, ok)
 			assert.Equal(t, expectedEvent, event)
 		}


### PR DESCRIPTION
Ensuring the atomicity of individual operations inevitably leads to the need for a **big lock**，So I have defined a lock for the currently implemented String data structure.

To facilitate traversal of different data structure types in the future,  the locks are stored using a map.

Add an exclusive lock during write operations, and add a shared lock during read operations.

This should fix the problem mentioned in **issue #19**, but performance needs to be optimized.



